### PR TITLE
Update ibase_driver.php

### DIFF
--- a/system/database/drivers/ibase/ibase_driver.php
+++ b/system/database/drivers/ibase/ibase_driver.php
@@ -204,7 +204,7 @@ class CI_DB_ibase_driver extends CI_DB {
 	public function insert_id($generator_name, $inc_by = 0)
 	{
 		//If a generator hasn't been used before it will return 0
-		return ibase_gen_id('"'.$generator_name.'"', $inc_by);
+		return ibase_gen_id($generator_name, $inc_by);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
insert_id() returns a 'GENERATOR NAME NOT FOUND' error. This fix removes the quotes that were being added to the name.

Tested against "Server LI-V2.5.2.26539 Firebird 2.5".
